### PR TITLE
bump ministryofjustice/github-actions v14 to v18.2.5

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.1
-      - uses: ministryofjustice/github-actions/code-formatter@v14
+      - uses: ministryofjustice/github-actions/code-formatter@v18.2.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tf-static-analysis.yml
+++ b/.github/workflows/tf-static-analysis.yml
@@ -50,7 +50,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@v14
+      uses: ministryofjustice/github-actions/terraform-static-analysis@v18.2.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
bump ministryofjustice/github-actions v14 to v18.2.5
Test afterwards to see if dependabot then bumps again from v18.2.5 to latest v18.3.1