### PR TITLE
change github actions pinned to sha

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: ministryofjustice/github-actions/code-formatter@v18.4.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ministryofjustice/github-actions/code-formatter@721b0f273fc8356611cb18b3dfc02074d59217da # v18.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tf-static-analysis.yml
+++ b/.github/workflows/tf-static-analysis.yml
@@ -48,7 +48,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@v18.4.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@721b0f273fc8356611cb18b3dfc02074d59217da # v18.4.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
change github actions pinned to sha
as per [https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide)